### PR TITLE
[BUG] make sure span payload data are utf-8 safe string

### DIFF
--- a/client/otel/opentelemetry.go
+++ b/client/otel/opentelemetry.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	rc "github.com/smallnest/rpcx/share"
@@ -52,7 +53,7 @@ func (p *OpenTelemetryPlugin) PreCall(ctx context.Context, servicePath, serviceM
 	spanName := fmt.Sprintf("rpcx.client.%s.%s", servicePath, serviceMethod)
 	ctx1, span := p.tracer.Start(ctx0, spanName)
 	span.AddEvent("PreCall", trace.WithAttributes(
-		attribute.String(rpcClientRequestMessageKey, fmt.Sprintf("%+v", args)),
+		attribute.String(rpcClientRequestMessageKey, strings.ToValidUTF8(fmt.Sprintf("%+v", args), " ")),
 	))
 	if p.recorder != nil {
 		attrs := []attribute.KeyValue{semconv.RPCService(servicePath), semconv.RPCMethod(serviceMethod)}
@@ -70,7 +71,7 @@ func (p *OpenTelemetryPlugin) PostCall(ctx context.Context, servicePath, service
 	defer span.End()
 
 	span.AddEvent("PostCall", trace.WithAttributes(
-		attribute.String(rpcClientResponseMessageKey, fmt.Sprintf("%+v", reply)),
+		attribute.String(rpcClientResponseMessageKey, strings.ToValidUTF8(fmt.Sprintf("%+v", reply), " ")),
 	))
 	attrs := []attribute.KeyValue{semconv.RPCService(servicePath), semconv.RPCMethod(serviceMethod)}
 	if err != nil {

--- a/server/otel/opentelemetry.go
+++ b/server/otel/opentelemetry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/smallnest/rpcx/protocol"
@@ -108,8 +109,8 @@ func (p OpenTelemetryPlugin) PreHandleRequest(ctx context.Context, r *protocol.M
 	)
 	span.AddEvent(tracingEventRpcxPreHandleRequest, trace.WithAttributes(
 		attribute.String(tracingEventRpcxPreHandleRequestPath, spanName),
-		attribute.String(tracingEventRpcxPreHandleRequestMetadata, fmt.Sprintf("%+v", r.Metadata)),
-		attribute.String(tracingEventRpcxPreHandleRequestPayload, string(r.Payload)),
+		attribute.String(tracingEventRpcxPreHandleRequestMetadata, strings.ToValidUTF8(fmt.Sprintf("%+v", r.Metadata), " ")),
+		attribute.String(tracingEventRpcxPreHandleRequestPayload, strings.ToValidUTF8(string(r.Payload), " ")),
 	))
 	if p.recorder != nil {
 		attrs := metric.WithAttributes(semconv.RPCService(r.ServicePath), semconv.RPCMethod(r.ServiceMethod))
@@ -129,8 +130,8 @@ func (p OpenTelemetryPlugin) PostWriteResponse(ctx context.Context, req *protoco
 	defer span.End()
 
 	span.AddEvent(tracingEventRpcxPostWriteResponse, trace.WithAttributes(
-		attribute.String(tracingEventRpcxPostWriteResponseMetadata, fmt.Sprintf("%+v", res.Metadata)),
-		attribute.String(tracingEventRpcxPostWriteResponsePayload, string(res.Payload)),
+		attribute.String(tracingEventRpcxPostWriteResponseMetadata, strings.ToValidUTF8(fmt.Sprintf("%+v", res.Metadata), " ")),
+		attribute.String(tracingEventRpcxPostWriteResponsePayload, strings.ToValidUTF8(string(res.Payload), " ")),
 	))
 
 	attrs := []attribute.KeyValue{semconv.RPCService(req.ServicePath), semconv.RPCMethod(req.ServiceMethod)}


### PR DESCRIPTION
opentelemetry payload string must be utf-8 safe, related to issue [Clarify that API users SHOULD use valid UTF-8 for exportable data #3421](https://github.com/open-telemetry/opentelemetry-specification/issues/3421), otherwise grpc exporter will be failed with error message "traces export: rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8"

payload in span Event must be converted to utf8 valid string with strings.ToValidUTF8 in both client and server.